### PR TITLE
Different replies based on submission type

### DIFF
--- a/app/responders/ropensci/reviewers_due_date_responder.rb
+++ b/app/responders/ropensci/reviewers_due_date_responder.rb
@@ -38,7 +38,7 @@ module Ropensci
         new_list = (list_of_reviewers + [reviewer]).uniq
         update_list("reviewers", new_list.join(", "))
         update_list("due-dates", add_reviewer_due_date(reviewer).join("\n"))
-        respond("#{reviewer} added to the reviewers list. Review due date is #{due_date}. Thanks #{reviewer} for accepting to review! Please refer to [our reviewer guide](https://devguide.ropensci.org/reviewerguide.html).")
+        respond("#{reviewer} added to the reviewers list. Review due date is #{due_date}. Thanks #{reviewer} for accepting to review! #{guide_link_by_submission_type}")
         add_collaborator(reviewer) if add_as_collaborator?(reviewer)
         add_assignee(reviewer) if add_as_assignee?(reviewer)
         process_labeling if new_list.size == 2
@@ -84,6 +84,18 @@ module Ropensci
 
     def due_date_in_days_from_now
       params[:due_date_days] || 21
+    end
+
+    def guide_link_by_submission_type
+      submission_type = read_value_from_body("submission-type").downcase
+      case submission_type
+      when "standard"
+        "Please refer to [our reviewer guide](https://devguide.ropensci.org/reviewerguide.html)."
+      when "stats"
+        "Please refer to [our reviewer guide](https://ropenscilabs.github.io/statistical-software-review-book/pkgreview.html)."
+      else
+        ""
+      end
     end
 
     def add_as_collaborator?(value)

--- a/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
+++ b/spec/responders/ropensci/reviewers_due_date_responder_spec.rb
@@ -52,12 +52,12 @@ describe Ropensci::ReviewersDueDateResponder do
         due_date = (Time.now + 10 * 86400).strftime("%Y-%m-%d")
         expect(due_date.strip).to_not be_empty
         expect(due_date).to_not eq(@new_due_date)
-        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{due_date}. Thanks @xuanxu for accepting to review! ")
+        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{due_date}. Thanks @xuanxu for accepting to review!")
         @responder.process_message(@msg)
       end
 
       it "should respond to github" do
-        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{@new_due_date}. Thanks @xuanxu for accepting to review! ")
+        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{@new_due_date}. Thanks @xuanxu for accepting to review!")
         @responder.process_message(@msg)
       end
 
@@ -65,6 +65,16 @@ describe Ropensci::ReviewersDueDateResponder do
         issue_body = "...Reviewers: <!--reviewers-list-->@maelle<!--end-reviewers-list-->" +
                      "<!--due-dates-list-->Due date for @maelle: 2121-12-31<!--end-due-dates-list--> ..." +
                      "<!--submission-type-->Standard<!--end-submission-type-->"
+        allow(@responder).to receive(:issue_body).and_return(issue_body)
+
+        expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{@new_due_date}. Thanks @xuanxu for accepting to review! Please refer to [our reviewer guide](https://devguide.ropensci.org/reviewerguide.html).")
+        @responder.process_message(@msg)
+      end
+
+      it "should respond the same for estandar and standard submission types" do
+        issue_body = "...Reviewers: <!--reviewers-list-->@maelle<!--end-reviewers-list-->" +
+                     "<!--due-dates-list-->Due date for @maelle: 2121-12-31<!--end-due-dates-list--> ..." +
+                     "<!--submission-type-->Estándar<!--end-submission-type-->"
         allow(@responder).to receive(:issue_body).and_return(issue_body)
 
         expect(@responder).to receive(:respond).with("@xuanxu added to the reviewers list. Review due date is #{@new_due_date}. Thanks @xuanxu for accepting to review! Please refer to [our reviewer guide](https://devguide.ropensci.org/reviewerguide.html).")
@@ -267,25 +277,34 @@ describe Ropensci::ReviewersDueDateResponder do
     end
   end
 
-  describe "#guide_link_by_submission_type" do
-    it "returns link to ropensci reviewers guide if submission type is Standard" do
+  describe "#respond_by_submission_type" do
+    before do
+      @due_date = (Time.now + 21 * 86400).strftime("%Y-%m-%d")
+      allow(@responder).to receive(:reviewer).and_return("@rev1")
+    end
+
+    it "replies link to ropensci reviewers guide if submission type is Standard" do
       allow(@responder).to receive(:read_value_from_body).with("submission-type").and_return("Standard")
-      expect(@responder.guide_link_by_submission_type).to eq("Please refer to [our reviewer guide](https://devguide.ropensci.org/reviewerguide.html).")
+      expect(@responder).to receive(:respond).with(/devguide.ropensci.org\/reviewerguide.html/)
+      @responder.respond_by_submission_type
     end
 
-    it "returns link to statistical software reviewers guide if submission type is Stats" do
+    it "replies link to statistical software reviewers guide if submission type is Stats" do
       allow(@responder).to receive(:read_value_from_body).with("submission-type").and_return("Stats")
-      expect(@responder.guide_link_by_submission_type).to eq("Please refer to [our reviewer guide](https://ropenscilabs.github.io/statistical-software-review-book/pkgreview.html).")
+      expect(@responder).to receive(:respond).with(/ropenscilabs.github.io\/statistical-software-review-book\/pkgreview.html/)
+      @responder.respond_by_submission_type
     end
 
-    it "is empty for unrecognized submission types" do
+    it "replies with generic response for unrecognized submission types" do
       allow(@responder).to receive(:read_value_from_body).with("submission-type").and_return("Whatever")
-      expect(@responder.guide_link_by_submission_type).to eq("")
+      expect(@responder).to receive(:respond).with("@rev1 added to the reviewers list. Review due date is #{@due_date}. Thanks @rev1 for accepting to review!")
+      @responder.respond_by_submission_type
     end
 
-    it "is empty if no submission type" do
+    it "replies with generic response if no submission type" do
       allow(@responder).to receive(:read_value_from_body).with("submission-type").and_return("")
-      expect(@responder.guide_link_by_submission_type).to eq("")
+      expect(@responder).to receive(:respond).with("@rev1 added to the reviewers list. Review due date is #{@due_date}. Thanks @rev1 for accepting to review!")
+      @responder.respond_by_submission_type
     end
   end
 


### PR DESCRIPTION
This PR changes the response of the `Reviewers Due Date` responder to include different reviewers guide links for `Standard` and `Stats` submission types.

Closes #17