### PR TITLE
switch URL for external editorcheck service

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -86,8 +86,8 @@ buffy:
       command: check package
       description: Various package checks
       message: Thanks, about to send the query.
-      url: http://kirby.ecohealthalliance.org:22051/editorcheck
-      method: post
+      url: http://138.68.123.59:8000/editorcheck
+      method: get
       data_from_issue:
         - repourl
         - repo


### PR DESCRIPTION
The Digital Ocean instance is finally up and running at this URL