### PR TITLE
add stats grade responder

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -43,6 +43,12 @@ buffy:
             - 6/approved
           only:
             - editors
+      - stats_grade:
+          command: stats grade
+          description: Show value of "statsgrade" variable
+          data_from_issue:
+            - statsgrade
+          message: "Issue template contains statsgrade = {{statsgrade}}"
     ropensci_reviewers:
       only:
         - editors

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -86,8 +86,8 @@ buffy:
       command: check package
       description: Various package checks
       message: Thanks, about to send the query.
-      url: http://kirby.ecohealthalliance.org:22051/editorcheck
-      method: post
+      url: http://138.68.123.59:8000/editorcheck
+      method: get
       data_from_issue:
         - repourl
         - repo


### PR DESCRIPTION
@noamross This is to aid resolution of disagreements on badge grades, through allowing editors to ping the bot to find the current stated grade. Commands to *change* that grade will follow.

@xuanxu Can you please check that this is all okay? One potential issue is that this variable only exists in one out of 6 issue templates. Thanks!