### PR TITLE
FinalizeTransfer responder

### DIFF
--- a/app/responders/ropensci/finalize_transfer_responder.rb
+++ b/app/responders/ropensci/finalize_transfer_responder.rb
@@ -1,0 +1,39 @@
+module Ropensci
+  class FinalizeTransferResponder < Responder
+
+    keyname :ropensci_finalize_transfer
+
+    def define_listening
+      @event_action = "issue_comment.created"
+      @event_regex = /\A@#{bot_name} finalize transfer of( [ \w-]+)?\.?\s*\z/i
+    end
+
+    def process_message(message)
+      return unless verify_package
+      Ropensci::ApprovedPackageWorker.perform_async(:finalize_transfer, params, locals, { package_name: @package_name, package_author: @package_author })
+    end
+
+    def verify_package
+      @package_name = match_data[1].to_s.strip
+      if @package_name.empty?
+        respond("Could not finalize transfer: Please, specify the name of the package (should match the name of the team at the rOpenSci org)")
+        return false
+      end
+
+      @package_author = context.issue_author.to_s.strip
+      if @package_author.empty?
+        respond("Could not finalize transfer: Could not identify package author")
+        return false
+      end
+      true
+    end
+
+    def description
+      "Adds package's repo to the rOpenSci team. This command should be issued after approval and transfer of the package."
+    end
+
+    def example_invocation
+      "@#{@bot_name} finalize transfer of package-name"
+    end
+  end
+end

--- a/app/responders/ropensci/finalize_transfer_responder.rb
+++ b/app/responders/ropensci/finalize_transfer_responder.rb
@@ -5,7 +5,7 @@ module Ropensci
 
     def define_listening
       @event_action = "issue_comment.created"
-      @event_regex = /\A@#{bot_name} finalize transfer of( [ \w-]+)?\.?\s*\z/i
+      @event_regex = /\A@#{bot_name} (finalize|finalise) transfer of( [ \w-]+)?\.?\s*\z/i
     end
 
     def process_message(message)
@@ -14,7 +14,7 @@ module Ropensci
     end
 
     def verify_package
-      @package_name = match_data[1].to_s.strip
+      @package_name = match_data[2].to_s.strip
       if @package_name.empty?
         respond("Could not finalize transfer: Please, specify the name of the package (should match the name of the team at the rOpenSci org)")
         return false

--- a/app/workers/ropensci/approved_package_worker.rb
+++ b/app/workers/ropensci/approved_package_worker.rb
@@ -10,6 +10,8 @@ module Ropensci
       case action.to_sym
       when :new_team
         new_team
+      when :finalize_transfer
+        finalize_transfer
       end
     end
 
@@ -20,6 +22,36 @@ module Ropensci
       unless user_to_invite.empty? || team_name.empty?
         invite_user_to_team(user_to_invite, "ropensci/#{team_name}")
       end
+    end
+
+    def finalize_transfer
+      org_team_name = "ropensci/#{params.package_name}"
+
+      if github_client.repository?(org_team_name)
+        package_team_id = team_id(org_team_name)
+
+        if package_team_id.nil?
+          package_team = add_new_team(org_team_name)
+          package_team_id = package_team.id if package_team
+          invite_user_to_team(params.package_author, org_team_name) if package_team_id
+        end
+
+        if package_team_id
+          url = "https://api.github.com/orgs/ropensci/teams/#{params.package_name}/repos/ropensci/#{params.package_name}"
+          parameters = { permission: "admin" }
+          response = Faraday.put(url, parameters.to_json, github_headers)
+          if response.status.between?(200, 299)
+            respond("Transfer completed. The `#{params.package_name}` team is now owner of [the repository](https://github.com/#{org_team_name})")
+          else
+            respond("Could not finalize transfer: Could not add owner rights to the `#{params.package_name}` team")
+          end
+        else
+          respond("Could not finalize transfer: Error creating the `#{org_team_name}` team")
+        end
+      else
+        respond("Can't find repository `#{org_team_name}`, have you forgotten to transfer it first?")
+      end
+
     end
   end
 end

--- a/docs/available_responders.md
+++ b/docs/available_responders.md
@@ -43,6 +43,7 @@ Buffy includes a list of Responders that can be used by configuring them in the 
 
    responders/ropensci/reviewers_due_date
    responders/ropensci/approve
+   responders/ropensci/finalize_transfer
    responders/ropensci/mint
    responders/ropensci/submit_review
 ```

--- a/docs/responders/ropensci/finalize_transfer.md
+++ b/docs/responders/ropensci/finalize_transfer.md
@@ -1,0 +1,36 @@
+ROpenSci :: Finalize transfer
+=============================
+
+This responder is used to assing a recent approved and transfered package to a rOpenSci team. It needs owner rights to work.
+It performs a series of tasks:
+
+- Checks for the presence of the package-name repo in the rOpenSci GitHub organization
+- Creates a new team named like the package-name and invites the creator of the issue to it, if the team does not exists already.
+- Adds the package-name repo to the package-name team with admin rights so the members of the team can manage it
+
+## Listens to
+
+```
+@botname finalize transfer of package-name
+```
+
+## Requirements
+
+The _package-name_ must be specified in the command, otherwise an error message will be sent as reply.
+The bot must have owner rights.
+
+## Settings key
+
+`ropensci_finalize_transfer`
+
+
+
+## Example:
+
+```yaml
+...
+  responders:
+    ropensci_finalize_transfer:
+      only: editors
+...
+```

--- a/spec/responders/ropensci/finalize_transfer_responder_spec.rb
+++ b/spec/responders/ropensci/finalize_transfer_responder_spec.rb
@@ -1,0 +1,67 @@
+require_relative "../../spec_helper.rb"
+
+describe Ropensci::FinalizeTransferResponder do
+
+  subject do
+    described_class
+  end
+
+  before do
+    settings = { env: {bot_github_user: "ropensci-review-bot"} }
+    @responder = subject.new(settings, {})
+
+  end
+
+  describe "listening" do
+    it "should listen to new comments" do
+      expect(@responder.event_action).to eq("issue_comment.created")
+    end
+
+    it "should define regex" do
+      expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of")
+      expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of package-name")
+      expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of package-name  \r\n")
+      expect(@responder.event_regex).to_not match("@ropensci-review-bot finalize transfer of package-name. another-command")
+      expect(@responder.event_regex).to_not match("@ropensci-review-bot finalize transfer of package-name\r\nanother-command")
+    end
+  end
+
+  describe "#process_message" do
+    before do
+      @msg = "@ropensci-review-bot finalize transfer of great-package"
+      @responder.match_data = @responder.event_regex.match(@msg)
+      disable_github_calls_for(@responder)
+      @responder.context = OpenStruct.new(issue_id: 33,
+                                          issue_author: "opener",
+                                          repo: "openjournals/testing-approval",
+                                          sender: "author")
+    end
+
+    it "should verify presence of package name" do
+      msg = "@ropensci-review-bot finalize transfer of"
+      @responder.match_data = @responder.event_regex.match(msg)
+      expect(@responder).to receive(:respond).with("Could not finalize transfer: Please, specify the name of the package (should match the name of the team at the rOpenSci org)")
+      @responder.process_message(msg)
+    end
+
+    it "should verify presence of package author" do
+      msg = "@ropensci-review-bot finalize transfer of nice-package"
+      @responder.match_data = @responder.event_regex.match(msg)
+      @responder.context[:issue_author] = nil
+      expect(@responder).to receive(:respond).with("Could not finalize transfer: Could not identify package author")
+      @responder.process_message(msg)
+    end
+
+    it "should create a job to finalize transfer" do
+      expect(Ropensci::ApprovedPackageWorker).to receive(:perform_async).
+                                                 with(:finalize_transfer,
+                                                      @responder.params,
+                                                      @responder.locals,
+                                                      {package_author: "opener", package_name: "great-package"})
+
+      @responder.process_message(@msg)
+    end
+
+
+  end
+end

--- a/spec/responders/ropensci/finalize_transfer_responder_spec.rb
+++ b/spec/responders/ropensci/finalize_transfer_responder_spec.rb
@@ -20,6 +20,7 @@ describe Ropensci::FinalizeTransferResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of")
       expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of package-name")
+      expect(@responder.event_regex).to match("@ropensci-review-bot finalise transfer of package-name")
       expect(@responder.event_regex).to match("@ropensci-review-bot finalize transfer of package-name  \r\n")
       expect(@responder.event_regex).to_not match("@ropensci-review-bot finalize transfer of package-name. another-command")
       expect(@responder.event_regex).to_not match("@ropensci-review-bot finalize transfer of package-name\r\nanother-command")

--- a/spec/workers/ropensci/approved_package_worker_spec.rb
+++ b/spec/workers/ropensci/approved_package_worker_spec.rb
@@ -14,6 +14,11 @@ describe Ropensci::ApprovedPackageWorker do
       expect(@worker).to receive(:new_team)
       @worker.perform(:new_team, @config, @locals, {})
     end
+
+    it "should run finalize_transfer action" do
+      expect(@worker).to receive(:finalize_transfer)
+      @worker.perform(:finalize_transfer, @config, @locals, {})
+    end
   end
 
   describe "#new_team" do
@@ -39,6 +44,61 @@ describe Ropensci::ApprovedPackageWorker do
       @worker.params = OpenStruct.new({team_name: ""})
       expect(@worker).to_not receive(:invite_user_to_team)
       @worker.new_team
+    end
+  end
+
+  describe "#finalize_transfer" do
+    before do
+      @worker = described_class.new
+      @worker.context = {}
+      @worker.params = OpenStruct.new({ package_name: "test-package", package_author: "test-package_author" })
+      disable_github_calls_for(@worker)
+      allow(@worker).to receive(:github_access_token).and_return("123ABC")
+    end
+
+    it "should check for presence of the transfered repo" do
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).with("ropensci/test-package").and_return(false)
+      expect(@worker).to receive(:respond).with("Can't find repository `ropensci/test-package`, have you forgotten to transfer it first?")
+      @worker.finalize_transfer
+    end
+
+    it "should create team and invite author if it doesn't exist" do
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).with("ropensci/test-package").and_return(true)
+      expect(@worker).to receive(:team_id).with("ropensci/test-package").and_return(nil)
+      expect(@worker).to receive(:add_new_team).with("ropensci/test-package").and_return(double(id: 1))
+      expect(@worker).to receive(:invite_user_to_team).with("test-package_author", "ropensci/test-package")
+
+      expect(Faraday).to receive(:put).and_return(double(status: 200))
+      @worker.finalize_transfer
+    end
+
+    it "should reply error message if can't create the team" do
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).with("ropensci/test-package").and_return(true)
+      expect(@worker).to receive(:team_id).with("ropensci/test-package").and_return(nil)
+      expect(@worker).to receive(:add_new_team).with("ropensci/test-package").and_return(nil)
+
+      expect(@worker).to receive(:respond).with("Could not finalize transfer: Error creating the `ropensci/test-package` team")
+      @worker.finalize_transfer
+    end
+
+    it "should add repo to team with admin rights" do
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).with("ropensci/test-package").and_return(true)
+      expect(@worker).to receive(:team_id).with("ropensci/test-package").and_return(123)
+
+      expect(Faraday).to receive(:put).and_return(double(status: 200))
+      expected_response = "Transfer completed. The `test-package` team is now owner of [the repository](https://github.com/ropensci/test-package)"
+      expect(@worker).to receive(:respond).with(expected_response)
+      @worker.finalize_transfer
+    end
+
+    it "should reply error message if can't add repo to team with admin rights" do
+      allow_any_instance_of(Octokit::Client).to receive(:repository?).with("ropensci/test-package").and_return(true)
+      expect(@worker).to receive(:team_id).with("ropensci/test-package").and_return(123)
+
+      expect(Faraday).to receive(:put).and_return(double(status: 403))
+      expected_response = "Could not finalize transfer: Could not add owner rights to the `test-package` team"
+      expect(@worker).to receive(:respond).with(expected_response)
+      @worker.finalize_transfer
     end
   end
 end


### PR DESCRIPTION
This PR adds a `finalize transfer for <package-name>` command that will:

- Check for the presence of the `package-name` repo in the rOpenSci GitHub organization
- Create a new team named `package-name` and invites the creator of the issue to it, if the team does not exists already
- Add the `package-name` repo to the `package-name` team with admin rights so the members of the team can manage it


Re: #39 