### PR TITLE
ISO-8601 dates in Airtable

### DIFF
--- a/app/workers/ropensci/airtable_worker.rb
+++ b/app/workers/ropensci/airtable_worker.rb
@@ -74,7 +74,7 @@ module Ropensci
       if review_entry
         review_entry["review_url"] = params.review_url
         review_entry["review_hours"] = params.review_time
-        review_entry["review_date"] = Date.parse(params.review_date).strftime("%m/%d/%Y")
+        review_entry["review_date"] = Date.parse(params.review_date).strftime("%Y-%m-%d")
         review_entry.save
 
         respond("Logged review for _#{reviewer}_ (hours: #{params.review_time})")
@@ -126,7 +126,7 @@ module Ropensci
                                       name: name_or_github_login(author),
                                       email: author.email,
                                       github: "https://github.com/#{author.login}",
-                                      date: Time.now.strftime("%m/%d/%Y"),
+                                      date: Time.now.strftime("%Y-%m-%d"),
                                       role: "author1")
       end
 
@@ -135,7 +135,7 @@ module Ropensci
                                       name: name_or_github_login(reviewer),
                                       email: reviewer.email,
                                       github: "https://github.com/#{reviewer.login}",
-                                      date: Time.now.strftime("%m/%d/%Y"),
+                                      date: Time.now.strftime("%Y-%m-%d"),
                                       role: "reviewer")
       end
 
@@ -144,7 +144,7 @@ module Ropensci
                                       name: name_or_github_login(other),
                                       email: other.email,
                                       github: "https://github.com/#{other.login}",
-                                      date: Time.now.strftime("%m/%d/%Y"),
+                                      date: Time.now.strftime("%Y-%m-%d"),
                                       role: "author-others")
       end
     end

--- a/spec/workers/ropensci/airtable_worker_spec.rb
+++ b/spec/workers/ropensci/airtable_worker_spec.rb
@@ -205,7 +205,7 @@ describe Ropensci::AirtableWorker do
 
         expect(review_in_airtable["review_url"]).to eq("review-url")
         expect(review_in_airtable["review_hours"]).to eq("9.5")
-        expect(review_in_airtable["review_date"]).to eq(Time.now.strftime("%m/%d/%Y"))
+        expect(review_in_airtable["review_date"]).to eq(Time.now.strftime("%Y-%m-%d"))
       end
 
       it "should reply a success message" do
@@ -273,7 +273,7 @@ describe Ropensci::AirtableWorker do
 
     describe "updates slack-invites Airtable" do
       let(:slack_invites_table) { double(create: true) }
-      let(:expected_params) { {package: "TestPackage", date: Date.today.strftime("%m/%d/%Y")} }
+      let(:expected_params) { {package: "TestPackage", date: Date.today.strftime("%Y-%m-%d")} }
       let(:reviewer1) { OpenStruct.new(login: "rev1", name: "Reviewer One", email: "one@reviewe.rs") }
       let(:reviewer2) { OpenStruct.new(login: "rev2", name: "Reviewer Two", email: "two@reviewe.rs") }
       let(:author1) { OpenStruct.new(login: "author1", name: "Author One", email: "one@autho.rs") }


### PR DESCRIPTION
This PR changes the API calls to Airtable to use dates in ISO format.

Closes #48 