### PR TITLE
Grant access to the check package command to issue authors & reviewers

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -92,6 +92,10 @@ buffy:
       name: editorcheck
       only:
         - editors
+      authorized_roles_in_issue:
+        - author1
+        - author-others
+        - reviewers-list
       command: check package
       description: Various package checks
       message: Thanks, about to send the query.


### PR DESCRIPTION
This PR allows users listed in a issue under the `author1`, `author-others` and `reviewers-list` fields to run the `check package` command.

Closes: #34