### PR TITLE
fix welcome and initial_values responders

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -25,6 +25,15 @@ buffy:
         value_matches:
           submission-type: "Standard|Estándar|Stats"
       message: "Thanks for submitting to rOpenSci, our editors and @ropensci-review-bot will reply soon. Type `@ropensci-review-bot help` for help."
+      external_service:
+        name: editorcheck
+        url: http://138.68.123.59:8000/editorcheck
+        method: get
+        data_from_issue:
+          - repo
+          - repourl
+          - issue_id
+        template_file: goodpractice.md
     basic_command:
       - code_of_conduct:
           command: code of conduct
@@ -107,6 +116,9 @@ buffy:
         - issue_id
       template_file: goodpractice.md
     initial_values:
+      if:
+        value_matches:
+          submission-type: "Standard|Estándar|Stats"
       values:
         - author1:
           - heading: Submitting Author


### PR DESCRIPTION
@maelle It was my mistake - I thought these lines were duplicated, and uninentionally deleted the `external_service` call in the welcome responder. This commit also restricts the initial values check to full submissions only.