### PR TITLE
Configurable deadline reminders

### DIFF
--- a/app/workers/ropensci/reminder_review_deadline_worker.rb
+++ b/app/workers/ropensci/reminder_review_deadline_worker.rb
@@ -24,11 +24,10 @@ module Ropensci
     def due_date_for(reviewer)
       @list_of_due_dates ||= read_value_from_body("due-dates-list").strip.split("\n").map(&:strip)
 
-      entry = @list_of_due_dates.select {|entry| entry.match?(/^Due date for #{reviewer}:/)}.first
+      entry = @list_of_due_dates.select {|entry| entry.match?(/^Due date for #{reviewer}: \d\d\d\d-\d\d-\d\d/)}.first
       return nil if entry.nil?
 
-      due_date_string = /^Due date for #{reviewer}: ([\d-]+)/.match(entry)[1]
-      return nil if due_date.nil?
+      due_date_string = /^Due date for #{reviewer}: (\d\d\d\d-\d\d-\d\d)/.match(entry)[1]
 
       Date.parse(due_date_string)
     end

--- a/app/workers/ropensci/reminder_review_deadline_worker.rb
+++ b/app/workers/ropensci/reminder_review_deadline_worker.rb
@@ -1,0 +1,36 @@
+require 'date'
+
+module Ropensci
+  class ReminderReviewDeadlineWorker < BuffyWorker
+
+    def perform(locals, params)
+      load_context_and_env(locals)
+      reminder_params = OpenStruct.new(params)
+
+      return false if issue.state == "closed"
+      return false if reminder_params.template_file.nil?
+
+      current_due_date = due_date_for(reminder_params.reviewer)
+
+      if current_due_date && Date.today + reminder_params.days_before_deadline.to_i == current_due_date
+        info = { reviewer: reminder_params.reviewer,
+                 days_before_deadline: reminder_params.days_before_deadline,
+                 due_date: current_due_date.strftime('%Y-%m-%d') }
+
+        respond_external_template(reminder_params.template_file, info)
+      end
+    end
+
+    def due_date_for(reviewer)
+      @list_of_due_dates ||= read_value_from_body("due-dates-list").strip.split("\n").map(&:strip)
+
+      entry = @list_of_due_dates.select {|entry| entry.match?(/^Due date for #{reviewer}:/)}.first
+      return nil if entry.nil?
+
+      due_date_string = /^Due date for #{reviewer}: ([\d-]+)/.match(entry)[1]
+      return nil if due_date.nil?
+
+      Date.parse(due_date_string)
+    end
+  end
+end

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -73,6 +73,9 @@ buffy:
         - 3/reviewer(s)-assigned
       remove_labels:
         - 2/seeking-reviewer(s)
+      reminder:
+        days_before_deadline: 2
+        template_file: reminder.md
     assign_editor:
       message: "The editor guide can be found at https://devguide.ropensci.org/editorguide.html#editorchecklist"
       only:

--- a/docs/responders/ropensci/reviewers_due_date.md
+++ b/docs/responders/ropensci/reviewers_due_date.md
@@ -37,6 +37,15 @@ The body of the issue should have a couple of placeholders marked with HTML comm
 :add_as_assignee: *<Boolean>* Optional. If true, the new reviewer will be added as assignee to the issue. Default value is **false**.
 
 :add_as_collaborator: *<Boolean>* Optional. If true, the new reviewer it will be added as collaborator to the repo. Default value is **false**.
+
+:reminder: Used to configure automatic reminders. See next.
+```
+
+Automatic reminders: To configure an automatic reminder for the reviewers the `reminder` param can be used with two nested options under it:
+```eval_rst
+:days_before_deadline: *<Integer>* Optional. Configure when the reminder will be posted (how many days before the dealine for the review). Default value: **4**
+
+:template_file: The template file to use for the reminder (will receive variables: *reviewer*, *days_before_deadline* and *due_date*).
 ```
 
 For the **Airtable** connection to work two parameters must be present in the `env` section of the settings file, configured using environment variable:
@@ -58,7 +67,7 @@ For the **Airtable** connection to work two parameters must be present in the `e
 ...
 ```
 
-**With labeling, changing no_reviewer_text, limiting access and only if there's an editor already assigned:**
+**With labeling, changing no_reviewer_text, setting a reminder, limiting access and only if there's an editor already assigned:**
 ```yaml
 ...
   responders:
@@ -72,6 +81,9 @@ For the **Airtable** connection to work two parameters must be present in the `e
         - 3/reviewer(s)-assigned
       remove_labels:
         - 2/seeking-reviewer(s)
+      reminder:
+        days_before_deadline: 4
+        template_file: reminder.md
 ...
 ```
 

--- a/spec/workers/ropensci/reminder_review_deadline_worker_spec.rb
+++ b/spec/workers/ropensci/reminder_review_deadline_worker_spec.rb
@@ -1,0 +1,81 @@
+require_relative "../../spec_helper.rb"
+
+describe Ropensci::ReminderReviewDeadlineWorker do
+  before do
+    @worker = described_class.new
+    disable_github_calls_for(@worker)
+  end
+
+  describe "perform" do
+    before do
+      @locals = { issue_id: 33,
+                  issue_author: "author",
+                  repo: "ropensci/reviews",
+                  sender: "editor",
+                  bot_name: "ropensci-review-bot" }
+
+      @params = { days_before_deadline: 2, template_file: "reminder.md", reviewer: "@reviewer33"}
+    end
+    it "should do nothing if issue is closed" do
+      expect(@worker).to receive(:issue).and_return(double(state: "closed"))
+      expect(@worker).to_not receive(:respond_external_template)
+
+      @worker.perform(@locals, @params)
+    end
+
+    it "should do nothing if no reply template configured" do
+      expect(@worker).to receive(:issue).and_return(double(state: "open"))
+      expect(@worker).to_not receive(:respond_external_template)
+
+      @worker.perform(@locals, { days_before_deadline: 2, reviewer: "@reviewer33"})
+    end
+
+    it "should do nothing if due date for the reviewer" do
+      expect(@worker).to receive(:issue).and_return(double(state: "open"))
+      expect(@worker).to receive(:due_date_for).with("@reviewer33").and_return(nil)
+      expect(@worker).to_not receive(:respond_external_template)
+
+      @worker.perform(@locals, @params)
+    end
+
+    it "should do nothing if wrong day" do
+      five_days_from_now = Date.parse((Time.now + 5*86400).strftime("%Y-%m-%d"))
+      expect(@worker).to receive(:issue).and_return(double(state: "open"))
+      expect(@worker).to receive(:due_date_for).with("@reviewer33").and_return(five_days_from_now)
+      expect(@worker).to_not receive(:respond_external_template)
+
+      @worker.perform(@locals, @params)
+    end
+
+    it "should reply reminder using the template" do
+      due_date = (Time.now + 2*86400).strftime("%Y-%m-%d")
+      issue_test_body = "<!--due-dates-list-->Due date for @reviewer33: #{due_date}<!--end-due-dates-list-->"
+      expect(@worker).to receive(:issue).and_return(double(state: "open", body: issue_test_body)).twice
+
+      expected_info =  { reviewer: "@reviewer33", days_before_deadline: 2, due_date: due_date }
+
+      expect(@worker).to receive(:respond_external_template).with("reminder.md", expected_info)
+      @worker.perform(@locals, @params)
+    end
+  end
+
+  describe "due_date_for" do
+    before do
+      due_dates_list = ["Due date for @Reviewer_A: 11121-invalid-date", "Due date for @Reviewer_B: 2022-06-18"].join("\n")
+      expect(@worker).to receive(:read_value_from_body).and_return(due_dates_list)
+    end
+
+    it "should be nil if no entry for the reviewer" do
+      expect(@worker.due_date_for("@Reviewer_C")).to be_nil
+    end
+
+    it "should be nil if invalid due_date for the reviewer" do
+      expect(@worker.due_date_for("@Reviewer_A")).to be_nil
+
+    end
+
+    it "should parse the due date for the reviewer" do
+      expect(@worker.due_date_for("@Reviewer_B")).to eq(Date.parse("2022-06-18"))
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an optional feature to the `ropensci_reviewers` responder to set a reminder when a reviewers is assigned.

Reminders are configured in the `ropensci_reviewers` responder config with the `reminder` option.
The parameters for the reminders are:
- days_before_deadline: 
  How many days before the review's due date the reminder will be posted (default 4)
- template_file: 
  The template file to be used for the reminder. Passed variables to ir are: reviewer, days_before_deadline & due_date 

Example:
```yaml
    ropensci_reviewers:
      only:
        - editors
      no_reviewer_text: "TBD"
      add_labels:
        - 3/reviewer(s)-assigned
      remove_labels:
        - 2/seeking-reviewer(s)
      reminder:
        days_before_deadline: 2
        template_file: reminder.md
```

Ref: #56