### PR TITLE
Fix external services config

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -119,10 +119,10 @@ buffy:
           method: get
           query_params:
             secret: <%= ENV['PKGCHECK_TOKEN'] %>
-            data_from_issue:
-              - repo
-              - repourl
-              - issue_id
+          data_from_issue:
+            - repo
+            - repourl
+            - issue_id
           template_file: goodpractice.md
       - srrcheck:
           only:
@@ -133,10 +133,10 @@ buffy:
           method: get
           query_params:
             secret: <%= ENV['PKGCHECK_TOKEN'] %>
-            data_from_issue:
-              - repo
-              - repourl
-              - issue_id
+          data_from_issue:
+            - repo
+            - repourl
+            - issue_id
           silent: true
 
     initial_values:


### PR DESCRIPTION
The `data_from_issue` info was being sent incorrectly because it was nested under `query_params`.
This PR should fix that.

Re: https://github.com/ropensci-org/buffy/issues/80#issuecomment-1206477733