### PR TITLE
Fill package field in the reviews table

### DIFF
--- a/app/responders/ropensci/submit_review_responder.rb
+++ b/app/responders/ropensci/submit_review_responder.rb
@@ -34,11 +34,12 @@ module Ropensci
       end
 
       reviewers = read_value_from_body("reviewers-list")
+      package_repo = read_value_from_body("repourl")
 
       comment_date = comment.created_at
       reviewer = comment.user.login
 
-      review_data = { reviewer: reviewer, review_date: comment_date, review_time: review_time, review_url: review_url, reviewers: reviewers }
+      review_data = { reviewer: reviewer, review_date: comment_date, review_time: review_time, review_url: review_url, reviewers: reviewers, package_repo: package_repo }
       Ropensci::AirtableWorker.perform_async(:submit_review, params, locals, review_data)
     end
 

--- a/app/workers/ropensci/airtable_worker.rb
+++ b/app/workers/ropensci/airtable_worker.rb
@@ -75,6 +75,7 @@ module Ropensci
         review_entry["review_url"] = params.review_url
         review_entry["review_hours"] = params.review_time
         review_entry["review_date"] = Date.parse(params.review_date).strftime("%Y-%m-%d")
+        review_entry["package"] = params.package_repo
         review_entry.save
 
         respond("Logged review for _#{reviewer}_ (hours: #{params.review_time})")

--- a/spec/responders/ropensci/submit_reviewer_responder_spec.rb
+++ b/spec/responders/ropensci/submit_reviewer_responder_spec.rb
@@ -35,7 +35,8 @@ describe Ropensci::SubmitReviewResponder do
 
   describe "#process_message" do
     before do
-      @issue_body = "... <!--reviewers-list-->@reviewer1, @reviewer2<!--end-reviewers-list--> ..."
+      @issue_body = "... <!--repourl-->https://ropensci.packages/test<!--end-repourl--> ..." +
+                    "... <!--reviewers-list-->@reviewer1, @reviewer2<!--end-reviewers-list--> ..."
       @valid_comment_url = "https://github.com/ropensci/testing/issues/32#issuecomment-12345678"
 
       disable_github_calls_for(@responder)
@@ -92,7 +93,7 @@ describe Ropensci::SubmitReviewResponder do
       comment = double(created_at: comment_created_at, user: double(login: "reviewer1"))
       expected_params = {all_reviews_label: "4/review-in-awaiting-changes"}
       expected_locals = {bot_name: "ropensci-review-bot", issue_author: "opener", issue_id: 32, repo: "ropensci/testing", sender: "xuanxu", match_data_1: @valid_comment_url, match_data_2: "10.5", match_data_3: "hours"}
-      expected_review_data = { reviewer: "reviewer1", review_date: comment_created_at, review_time: "10.5", review_url: @valid_comment_url, reviewers: "@reviewer1, @reviewer2" }
+      expected_review_data = { reviewer: "reviewer1", review_date: comment_created_at, review_time: "10.5", review_url: @valid_comment_url, reviewers: "@reviewer1, @reviewer2", package_repo: "https://ropensci.packages/test" }
 
       @responder.match_data = @responder.event_regex.match(msg)
       expect(Ropensci::AirtableWorker).to receive(:perform_async).with(:submit_review,

--- a/spec/workers/ropensci/airtable_worker_spec.rb
+++ b/spec/workers/ropensci/airtable_worker_spec.rb
@@ -176,7 +176,8 @@ describe Ropensci::AirtableWorker do
                                         review_time: "9.5",
                                         review_date: Time.now.to_s,
                                         review_url: "review-url",
-                                        reviewers: "@reviewer21, @reviewer42"})
+                                        reviewers: "@reviewer21, @reviewer42",
+                                        package_repo: "https://ropensci.org/test-package" })
       @worker.airtable_config = {api_key: "ABC", base_id: "123"}
       @responder_config = OpenStruct.new({ label_when_all_reviews_in: "4/review-in-awaiting-changes",
                                            unlabel_when_all_reviews_in: "3/reviewer(s)-assigned" })
@@ -198,6 +199,7 @@ describe Ropensci::AirtableWorker do
         expect(review_in_airtable["review_url"]).to be_nil
         expect(review_in_airtable["review_hours"]).to be_nil
         expect(review_in_airtable["review_date"]).to be_nil
+        expect(review_in_airtable["package"]).to be_nil
 
         expect(review_in_airtable).to receive(:save)
 
@@ -206,6 +208,7 @@ describe Ropensci::AirtableWorker do
         expect(review_in_airtable["review_url"]).to eq("review-url")
         expect(review_in_airtable["review_hours"]).to eq("9.5")
         expect(review_in_airtable["review_date"]).to eq(Time.now.strftime("%Y-%m-%d"))
+        expect(review_in_airtable["package"]).to eq("https://ropensci.org/test-package")
       end
 
       it "should reply a success message" do


### PR DESCRIPTION
This PR adds the **package repo url** to the `package` field of the reviews table when editors use the `submit review` command.

Closes #79