### PR TITLE
Activate the invite_author command

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -59,6 +59,7 @@ buffy:
         - 5/awaiting-reviewer(s)-response
       add_labels:
         - 6/approved
+    ropensci_invite_author:
     ropensci_finalize_transfer:
     ropensci_mint:
       only: editors


### PR DESCRIPTION
The `invite me to ropensci/<package-name>` command for package authors was not active. 
This PR adds it to the production config file