### PR TITLE
Update regex to allow intermediate periods in package names

### DIFF
--- a/app/responders/ropensci/approve_responder.rb
+++ b/app/responders/ropensci/approve_responder.rb
@@ -7,7 +7,7 @@ module Ropensci
 
     def define_listening
       @event_action = "issue_comment.created"
-      @event_regex = /\A@#{bot_name} approve( [ \.\w-]*[ \w-]+)?\.?\s*\z/i
+      @event_regex = /\A@#{bot_name} approve( [\.\w-]*[\w-]+)?\.?\s*\z/i
     end
 
     def process_message(message)

--- a/app/responders/ropensci/approve_responder.rb
+++ b/app/responders/ropensci/approve_responder.rb
@@ -7,7 +7,7 @@ module Ropensci
 
     def define_listening
       @event_action = "issue_comment.created"
-      @event_regex = /\A@#{bot_name} approve( [ \w-]+)?\.?\s*\z/i
+      @event_regex = /\A@#{bot_name} approve( [ \.\w-]*[ \w-]+)?\.?\s*\z/i
     end
 
     def process_message(message)

--- a/spec/responders/ropensci/approve_responder_spec.rb
+++ b/spec/responders/ropensci/approve_responder_spec.rb
@@ -20,6 +20,7 @@ describe Ropensci::ApproveResponder do
     it "should define regex" do
       expect(@responder.event_regex).to match("@ropensci-review-bot approve")
       expect(@responder.event_regex).to match("@ropensci-review-bot approve package-name")
+      expect(@responder.event_regex).to match("@ropensci-review-bot approve package.name")
       expect(@responder.event_regex).to match("@ropensci-review-bot approve package-name  \r\n")
       expect(@responder.event_regex).to_not match("@ropensci-review-bot approve package-name. another-command")
       expect(@responder.event_regex).to_not match("@ropensci-review-bot approve package-name\r\nanother-command")


### PR DESCRIPTION
This PR updated the regex for the `approve` command to allow names like `package.name`

Closes https://github.com/ropensci-org/buffy/issues/109