### PR TITLE
Update settings-production.yml

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -19,6 +19,10 @@ buffy:
       authorized_roles_in_issue:
         - author1
         - author-others
+      remove_labels:
+        - 4/review(s)-in-awaiting-changes
+      add_labels:
+        - 5/awaiting-reviewer(s)-response
     help:
     hello:
       hidden: true


### PR DESCRIPTION
@mpadge do you think it is what's needed to prevent https://github.com/ropensci/software-review/issues/698#issuecomment-2994009011 (when the response _had_ been submitted)?