### PR TITLE
add more welcome responder labels

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -52,7 +52,7 @@ buffy:
       if:
         value_matches:
           submission-type: "Pre-submission|pre-envio"
-        body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time)"
+        body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time|Probability)"
       add_labels:
         - "stats"
     welcome:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -41,6 +41,26 @@ buffy:
           - repourl
           - issue_id
         template_file: goodpractice.md
+    welcome:
+      if:
+        value_matches:
+          submission-type: "Pre-submission|pre-envio"
+      message: "Thanks for your pre-submission to rOpenSci, our editors will reply soon."
+      add_labels:
+        - "0/presubmission"
+    welcome:
+      if:
+        value_matches:
+          submission-type: "Pre-submission|pre-envio"
+        body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time)"
+      add_labels:
+        - "stats"
+    welcome:
+      if:
+        value_matches:
+          submission-type: "Stats"
+      add_labels:
+        - "stats"
     basic_command:
       - code_of_conduct:
           command: code of conduct

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -25,30 +25,6 @@ buffy:
     thanks:
       hidden: true
     welcome:
-      if:
-        value_matches:
-          submission-type: "Standard|Estándar|Stats"
-      message: "Thanks for submitting to rOpenSci, our editors and @ropensci-review-bot will reply soon. Type `@ropensci-review-bot help` for help."
-      # message: "⭐️ Thanks for submitting to rOpenSci.  We are taking a break for the holidays. Activities are currently paused until Jan 8th 2025. Please alert us here on or after that date to proceed with your submission. ⭐️"
-      add_labels:
-        - holding
-      external_service:
-        name: editorcheck
-        url: http://138.68.123.59:8000/editorcheck
-        method: get
-        data_from_issue:
-          - repo
-          - repourl
-          - issue_id
-        template_file: goodpractice.md
-    welcome:
-      if:
-        value_matches:
-          submission-type: "Pre-submission|pre-envio"
-      message: "Thanks for your pre-submission to rOpenSci, our editors will reply soon."
-      add_labels:
-        - "0/presubmission"
-    welcome:
       - standard:
           if:
             value_matches:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -49,18 +49,43 @@ buffy:
       add_labels:
         - "0/presubmission"
     welcome:
-      if:
-        value_matches:
-          submission-type: "Pre-submission|pre-envio"
-        body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time|Probability)"
-      add_labels:
-        - "stats"
-    welcome:
-      if:
-        value_matches:
-          submission-type: "Stats"
-      add_labels:
-        - "stats"
+      - standard:
+          if:
+            value_matches:
+              submission-type: "Standard|Estándar|Stats"
+          message: "Thanks for submitting to rOpenSci, our editors and @ropensci-review-bot will reply soon. Type `@ropensci-review-bot help` for help."
+          # message: "⭐️ Thanks for submitting to rOpenSci.  We are taking a break for the holidays. Activities are currently paused until Jan 8th 2025. Please alert us here on or after that date to proceed with your submission. ⭐️"
+          add_labels:
+            - holding
+          external_service:
+            name: editorcheck
+            url: http://138.68.123.59:8000/editorcheck
+            method: get
+            data_from_issue:
+              - repo
+              - repourl
+              - issue_id
+            template_file: goodpractice.md
+      - pre_submission:
+          if:
+            value_matches:
+              submission-type: "Pre-submission|pre-envio"
+          message: "Thanks for your pre-submission to rOpenSci, our editors will reply soon."
+          add_labels:
+            - "0/presubmission"
+      - pre_submission_stats:
+          if:
+            value_matches:
+              submission-type: "Pre-submission|pre-envio"
+            body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time|Probability)"
+          add_labels:
+            - "stats"
+      - submission_stats:
+          if:
+            value_matches:
+              submission-type: "Stats"
+          add_labels:
+            - "stats"
     basic_command:
       - code_of_conduct:
           command: code of conduct

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -31,8 +31,6 @@ buffy:
               submission-type: "Standard|Estándar|Stats"
           message: "Thanks for submitting to rOpenSci, our editors and @ropensci-review-bot will reply soon. Type `@ropensci-review-bot help` for help."
           # message: "⭐️ Thanks for submitting to rOpenSci.  We are taking a break for the holidays. Activities are currently paused until Jan 8th 2025. Please alert us here on or after that date to proceed with your submission. ⭐️"
-          add_labels:
-            - holding
           external_service:
             name: editorcheck
             url: http://138.68.123.59:8000/editorcheck


### PR DESCRIPTION
@xuanxu A review request here, please. This is an attempt to add a few initial labels on issue opening. Your [config docs](https://buffy-ropensci.readthedocs.io/en/latest/configuration.html) suggest that this should be the way - several distinct `welcome` responders, each with a different condition.

The one I'm unsure about is this:
```
    if:
        value_matches:
          submission-type: "Pre-submission|pre-envio"
        body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time)"
      add_labels:
        - "stats"
```
That's attempting to grep whether any of the statistical checkbox items in [this template](https://github.com/ropensci/software-review/blob/main/.github/ISSUE_TEMPLATE/B-submit-a-presubmission-inquiry.md) have been checked. Does that look right to you? Thanks in advance, and ping @maelle too