### PR TITLE
add 'pkgmatch' external service to config file

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -32,14 +32,23 @@ buffy:
           message: "Thanks for submitting to rOpenSci, our editors and @ropensci-review-bot will reply soon. Type `@ropensci-review-bot help` for help."
           # message: "⭐️ Thanks for submitting to rOpenSci.  We are taking a break for the holidays. Activities are currently paused until Jan 5th 2026. Please alert us here on or after that date to proceed with your submission. ⭐️"
           external_service:
-            name: editorcheck
-            url: http://138.68.123.59:8000/editorcheck
-            method: get
-            data_from_issue:
-              - repo
-              - repourl
-              - issue_id
-            template_file: goodpractice.md
+            - pkgmatch:
+              name: pkgmatch
+              url: http://138.68.123.59:8000/pkgmatch
+              method: get
+              data_from_issue:
+                - repo
+                - repourl
+                - issue_id
+            - editorcheck:
+              name: editorcheck
+              url: http://138.68.123.59:8000/editorcheck
+              method: get
+              data_from_issue:
+                - repo
+                - repourl
+                - issue_id
+              template_file: goodpractice.md
       - pre_submission:
           if:
             value_matches:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -33,22 +33,22 @@ buffy:
           # message: "⭐️ Thanks for submitting to rOpenSci.  We are taking a break for the holidays. Activities are currently paused until Jan 5th 2026. Please alert us here on or after that date to proceed with your submission. ⭐️"
           external_service:
             - pkgmatch:
-              name: pkgmatch
-              url: http://138.68.123.59:8000/pkgmatch
-              method: get
-              data_from_issue:
-                - repo
-                - repourl
-                - issue_id
+                name: pkgmatch
+                url: http://138.68.123.59:8000/pkgmatch
+                method: get
+                data_from_issue:
+                  - repo
+                  - repourl
+                  - issue_id
             - editorcheck:
-              name: editorcheck
-              url: http://138.68.123.59:8000/editorcheck
-              method: get
-              data_from_issue:
-                - repo
-                - repourl
-                - issue_id
-              template_file: goodpractice.md
+                name: editorcheck
+                url: http://138.68.123.59:8000/editorcheck
+                method: get
+                data_from_issue:
+                  - repo
+                  - repourl
+                  - issue_id
+                template_file: goodpractice.md
       - pre_submission:
           if:
             value_matches:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -47,6 +47,14 @@ buffy:
           message: "Thanks for your pre-submission to rOpenSci, our editors will reply soon."
           add_labels:
             - "0/presubmission"
+          external_service:
+            name: pkgmatch
+            url: http://138.68.123.59:8000/pkgmatch
+            method: get
+            data_from_issue:
+              - repourl
+              - repo
+              - issue_id
       - pre_submission_stats:
           if:
             value_matches:
@@ -54,6 +62,14 @@ buffy:
             body: "\\[x\\]\\s(Bayesian|Dimensionality|Machine|Regression|Exploratory|Spatial|Time|Probability)"
           add_labels:
             - "stats"
+          external_service:
+            name: pkgmatch
+            url: http://138.68.123.59:8000/pkgmatch
+            method: get
+            data_from_issue:
+              - repourl
+              - repo
+              - issue_id
       - submission_stats:
           if:
             value_matches:
@@ -170,6 +186,19 @@ buffy:
             - repourl
             - issue_id
           template_file: goodpractice.md
+      - pkgmatch:
+          only:
+            - editors
+          command: similar packages
+          description: List similar packages from rOpenSci and CRAN
+          url: http://138.68.123.59:8000/pkgmatch
+          method: get
+          query_params:
+            secret: <%= ENV['PKGCHECK_TOKEN'] %>
+          data_from_issue:
+            - repo
+            - repourl
+            - issue_id
       - srrcheck:
           only:
             - editors


### PR DESCRIPTION
@xuanxu This adds a new external service, which should be okay, but I've got one additional question: I want to also add the same service here:
https://github.com/ropensci-org/buffy/blob/1d8da825fd35bc276bcaf1a0f3e25120cf7e5785/config/settings-production.yml#L28-L42
using the service arrays that were merged in #123. How should the config then be specified for an array of services?

With two consecutive repeats like this:
```
          external_service:
            name: editorcheck
            url: http://138.68.123.59:8000/editorcheck
            ...
          external_service:
            name: pkgmatch
            url: http://138.68.123.59:8000/pkgmatch
            ...
```
Or some other way? Advice appreciated; thanks!
