### PR TITLE
Get external service names in WelcomeResponder

### DIFF
--- a/app/responders/welcome_responder.rb
+++ b/app/responders/welcome_responder.rb
@@ -48,8 +48,18 @@ class WelcomeResponder < Responder
   def external_service(service_params)
     return if service_params.nil? || service_params.empty?
 
-    services = service_params.is_a?(Array) ? service_params : [service_params]
-    services.each do |service_config|
+    external_services = []
+    if service_params.is_a?(Array)
+      service_params.each do |single_service|
+        single_service.each_pair do |service_name, service_config|
+          external_services << service_config.merge({ name: service_name.to_s})
+        end
+      end
+    else
+      external_services << service_params
+    end
+
+    external_services.each do |service_config|
       check_required_params(service_config)
       process_external_service(service_config, locals)
     end

--- a/spec/responders/welcome_responder_spec.rb
+++ b/spec/responders/welcome_responder_spec.rb
@@ -241,8 +241,8 @@ describe WelcomeResponder do
     before do
       settings = { env: {bot_github_user: "botsci"} }
       services = [
-        { name: "service1", url: "http://example1.com", data_from_issue: ["extra-data"] },
-        { name: "service2", url: "http://example2.com" }
+        { service1: { url: "http://example1.com", data_from_issue: ["extra-data"] }},
+        { service2: { url: "http://example2.com" }}
       ]
       @responder = subject.new(settings, {external_service: services})
       @responder.context = OpenStruct.new(issue_id: 33,


### PR DESCRIPTION
This PR fixes the WelcomeResponder to correctly set the name value when multiple external services are configured.

Fixes: #129 