### PR TITLE
fix stats badge endpoint url in stats_grade_worker

### DIFF
--- a/app/workers/ropensci/stats_grade_worker.rb
+++ b/app/workers/ropensci/stats_grade_worker.rb
@@ -15,7 +15,7 @@ module Ropensci
 
     def label
       parameters = { repo: context[:repo], issue_num: context[:issue_id] }
-      url = params.stats_badge_url || "http://138.68.123.59:8000/stats_badge"
+      url = params.stats_badge_url || "http://reviewbot.ropensci.org/stats_badge"
       headers = {}
 
       response = Faraday.get(url, parameters, headers)

--- a/docs/responders/ropensci/approve.md
+++ b/docs/responders/ropensci/approve.md
@@ -45,7 +45,7 @@ For the **Airtable** connection to work two parameters must be present in the `e
 ```
 
 For labeling the approved `stats` submissions an external service is used to get the proper versioned label.
-The url for the external service is by default: `http://138.68.123.59:8000/stats_badge`. This value can be changed using the optional `:stats_badge_url` param:
+The url for the external service is by default: `http://reviewbot.ropensci.org/stats_badge`. This value can be changed using the optional `:stats_badge_url` param:
 
 ```yaml
 ...

--- a/spec/workers/ropensci/stats_grade_worker_spec.rb
+++ b/spec/workers/ropensci/stats_grade_worker_spec.rb
@@ -26,7 +26,7 @@ describe Ropensci::StatsGradesWorker do
     end
 
     it "should call default external service to get label" do
-      expected_url = "http://138.68.123.59:8000/stats_badge"
+      expected_url = "http://reviewbot.ropensci.org/stats_badge"
       expected_parameters = { repo: "ropensci/tests", issue_num: 12}
       expect(Faraday).to receive(:get).with(expected_url, expected_parameters, {}).and_return(@response_ok)
 


### PR DESCRIPTION
For https://github.com/ropensci-org/badges/issues/27

@maelle Before the changes added in this PR, the old code was failing to return stats grades from the `stats_badge` endpoint of our server, and so no grade-specific badges were added. I'll add the ones you listed manually, and after this is merged and re-deployed, things should once again work properly. Thanks for catching this!